### PR TITLE
Fix UI startup

### DIFF
--- a/ui/mainwindow.py
+++ b/ui/mainwindow.py
@@ -1,6 +1,12 @@
 from PySide6.QtWidgets import (
-    QWidget, QVBoxLayout, QLabel, QPushButton, QFileDialog,
-    QHBoxLayout, QFrame, QApplication
+    QWidget,
+    QVBoxLayout,
+    QLabel,
+    QPushButton,
+    QFileDialog,
+    QHBoxLayout,
+    QFrame,
+    QApplication,
 )
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QPalette, QColor, QFont
@@ -86,9 +92,14 @@ class MainWindow(QWidget):
         }
         """
 
-# To run the UI manually (if needed):
-if __name__ == "__main__":
+
+def run_app() -> None:
+    """Launch the application and show the main window."""
     app = QApplication([])
     window = MainWindow()
     window.show()
     app.exec()
+
+# To run the UI manually (if needed):
+if __name__ == "__main__":
+    run_app()


### PR DESCRIPTION
## Summary
- restore run_app helper to launch the window
- clean up imports in `mainwindow.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python shortssplit.py` *(fails: No module named 'PySide6')*

------
https://chatgpt.com/codex/tasks/task_e_68501e8efb98832f81215d75c5a00a6e