### PR TITLE
Enable output video generation

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,3 @@
+from .shorts import generate_short
+
+__all__ = ["generate_short"]

--- a/core/shorts.py
+++ b/core/shorts.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import logging
+import tempfile
+from pathlib import Path
+
+from .ffmpeg_handler import build_stack
+from .subtitle_utils import save_srt
+from .whisper_wrapper import transcribe
+
+
+def generate_short(top: Path | str, bottom: Path | str, model_size: str = "base") -> Path:
+    """Create a short stacked video using the two provided clips.
+
+    Parameters
+    ----------
+    top: Path | str
+        Path to the top clip which will be transcribed.
+    bottom: Path | str
+        Path to the bottom clip.
+    model_size: str, optional
+        Whisper model size. Defaults to ``"base"``.
+
+    Returns
+    -------
+    Path
+        The path to the generated ``output.mp4`` file.
+    """
+    top_path = Path(top)
+    bottom_path = Path(bottom)
+    output_path = top_path.parent / "output.mp4"
+
+    logging.info("Transcribing top clip: %s", top_path)
+    srt_lines = transcribe(top_path, model_size=model_size)
+
+    with tempfile.NamedTemporaryFile(suffix=".srt", delete=False) as tmp:
+        subtitle_path = Path(tmp.name)
+        save_srt(srt_lines, subtitle_path)
+
+    try:
+        logging.info("Building stacked video -> %s", output_path)
+        build_stack(top_path, bottom_path, subtitle_path, output_path)
+    finally:
+        subtitle_path.unlink(missing_ok=True)
+
+    return output_path

--- a/ui/mainwindow.py
+++ b/ui/mainwindow.py
@@ -7,9 +7,12 @@ from PySide6.QtWidgets import (
     QHBoxLayout,
     QFrame,
     QApplication,
+    QMessageBox,
 )
 from PySide6.QtCore import Qt
-from PySide6.QtGui import QPalette, QColor, QFont
+from PySide6.QtGui import QFont
+
+from core import generate_short
 
 class MainWindow(QWidget):
     def __init__(self):
@@ -64,8 +67,16 @@ class MainWindow(QWidget):
             setattr(self, f"{clip_type}_clip", file_path)
 
     def create_short(self):
-        # This would trigger the main logic
+        try:
+            top = getattr(self, "top_clip")
+            bottom = getattr(self, "bottom_clip")
+        except AttributeError:
+            QMessageBox.warning(self, "Missing Clips", "Load both top and bottom clips first.")
+            return
+
         print("Generating short...")
+        output = generate_short(top, bottom)
+        QMessageBox.information(self, "Done", f"Created {output}")
 
     def stylesheet(self):
         return """


### PR DESCRIPTION
## Summary
- implement `generate_short` in `core/shorts.py` that transcribes and stacks clips
- expose `generate_short` via `core.__init__`
- connect the UI's **Create** button to actually generate the short video

## Testing
- `python -m py_compile shortssplit.py ui/mainwindow.py core/*.py`
- `python shortssplit.py --help` *(fails: ModuleNotFoundError for `faster_whisper`)*

------
https://chatgpt.com/codex/tasks/task_e_6850534b9cd4832fa423a5d7f53d7293