### PR TITLE
Allow forcing CPU mode for Whisper

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,13 @@ python shortssplit.py
 ```
 
 The transcriber tries to use your GPU first. If CUDA libraries are missing, it
-falls back to CPU automatically.
+falls back to CPU automatically. You can force CPU mode by setting:
+
+```bash
+set WHISPER_DEVICE=cpu  # Windows
+# or
+export WHISPER_DEVICE=cpu  # Unix-like
+```
 
 Drop your clips into the window:
 

--- a/core/whisper_wrapper.py
+++ b/core/whisper_wrapper.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from pathlib import Path
 from typing import List
 
@@ -21,9 +22,13 @@ def transcribe(
         Whisper model size. Defaults to ``"base"``.
     device: str, optional
         Device for inference (``"cpu"`` or ``"cuda"``/``"auto"``). Defaults to
-        ``"auto"``. If initialization fails (e.g., missing GPU libraries), the
+        ``"auto"``. Set the environment variable ``WHISPER_DEVICE`` to override
+        this value. If initialization fails (e.g., missing GPU libraries), the
         function falls back to CPU.
     """
+    env_device = os.getenv("WHISPER_DEVICE")
+    if env_device:
+        device = env_device
     logging.info("Transcribing %s", path)
     cache_key = (model_size, device)
     if cache_key not in _model_cache:


### PR DESCRIPTION
## Summary
- check `WHISPER_DEVICE` in `transcribe` to allow overriding the device
- document how to force CPU mode

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685056c4cd10832fa80504015fa58e9e