### PR TITLE
Switch to ASS subtitles

### DIFF
--- a/core/ffmpeg_handler.py
+++ b/core/ffmpeg_handler.py
@@ -11,8 +11,6 @@ def build_stack(
     bottom: Path,
     subtitle: Path,
     out_path: Path,
-    font_size: int = 24,
-    font_color: str = "white",
 ) -> None:
     """Create the stacked video with subtitles burned into the top clip."""
     duration = probe_duration(top)
@@ -21,16 +19,8 @@ def build_stack(
     sub_path = subtitle.as_posix()
     sub_path = re.sub(r'^([A-Za-z]):', r'\1\\:', sub_path, count=1)
 
-    # Subtitle styling
-    style = (
-        f"Fontsize={font_size},"
-        f"PrimaryColour=&H{_color_hex(font_color)}&,"
-        "Alignment=2,"
-        "OutlineColour=&H000000&,"
-        "BorderStyle=1,"
-        "Outline=2"
-    )
-    sub_filter = f"subtitles=filename='{sub_path}':force_style='{style}'"
+    # ASS subtitles
+    sub_filter = f"ass='{sub_path}'"
 
     # Scale→crop→subtitles on top; scale→crop→trim→setpts on bottom; then vstack
     filter_complex = (
@@ -63,12 +53,3 @@ def build_stack(
         logging.debug(result.stderr.decode())
         subprocess.run(cmd_x264, check=True)
 
-
-def _color_hex(name: str) -> str:
-    colors = {
-        "white":  "FFFFFF",
-        "black":  "000000",
-        "yellow": "FFFF00",
-        "red":    "FF0000",
-    }
-    return colors.get(name.lower(), "FFFFFF")

--- a/core/shorts.py
+++ b/core/shorts.py
@@ -5,7 +5,7 @@ import tempfile
 from pathlib import Path
 
 from .ffmpeg_handler import build_stack
-from .subtitle_utils import save_srt
+from .subtitle_utils import save_ass
 from .whisper_wrapper import transcribe
 
 
@@ -40,11 +40,11 @@ def generate_short(
     output_path = top_path.parent / "output.mp4"
 
     logging.info("Transcribing top clip: %s", top_path)
-    srt_lines = transcribe(top_path, model_size=model_size, device=device)
+    cues = transcribe(top_path, model_size=model_size, device=device)
 
-    with tempfile.NamedTemporaryFile(suffix=".srt", delete=False) as tmp:
+    with tempfile.NamedTemporaryFile(suffix=".ass", delete=False) as tmp:
         subtitle_path = Path(tmp.name)
-        save_srt(srt_lines, subtitle_path)
+        save_ass(cues, subtitle_path)
 
     try:
         logging.info("Building stacked video -> %s", output_path)

--- a/core/whisper_wrapper.py
+++ b/core/whisper_wrapper.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from pathlib import Path
-from typing import List
+from typing import List, Tuple
 
 from faster_whisper import WhisperModel
 
@@ -11,8 +11,8 @@ _model_cache = {}
 
 def transcribe(
     path: Path, model_size: str = "base", device: str = "auto"
-) -> List[str]:
-    """Transcribe audio and return SRT lines.
+) -> List[Tuple[float, float, str]]:
+    """Transcribe audio and return subtitle cues.
 
     Each subtitle cue contains up to three words for readability and is timed
     using word-level timestamps.
@@ -73,23 +73,4 @@ def transcribe(
     # Sort cues by start time in case segments are not sequential
     cues.sort(key=lambda c: c[0])
 
-    srt_lines = []
-    for i, (start, end, text) in enumerate(cues, start=1):
-        srt_lines.extend(
-            [
-                f"{i}",
-                f"{_format_time(start)} --> {_format_time(end)}",
-                text,
-                "",
-            ]
-        )
-    return srt_lines
-
-
-def _format_time(seconds: float) -> str:
-    """Format ``seconds`` as ``HH:MM:SS,mmm`` for SRT."""
-    ms_total = int(round(seconds * 1000))
-    hrs, ms_total = divmod(ms_total, 3600 * 1000)
-    mins, ms_total = divmod(ms_total, 60 * 1000)
-    secs, ms = divmod(ms_total, 1000)
-    return f"{hrs:02}:{mins:02}:{secs:02},{ms:03}"
+    return cues


### PR DESCRIPTION
## Summary
- generate ASS subtitle files instead of SRT
- embed ASS subtitles with ffmpeg using the `ass` filter
- provide default styling when writing ASS
- simplify `whisper_wrapper.transcribe` to return cues for ASS generation

## Testing
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_68510c9b1100832fb73344f2485f9d89