### PR TITLE
Add persistent settings and customization options

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ It uses [`faster-whisper`](https://github.com/guillaumekln/faster-whisper) for t
 - 🪞 Bottom clip loops or trims to match top duration automatically
 - 🔊 Audio only from top clip, normalized to not blow ears out
 - 🌗 Light/dark mode toggle (for when you're feeling emo)
+- 💾 Remembers last used clips and settings
+- 🎨 Custom subtitle style options
+- 🗄️ Choose output file name and location
+- 📣 Simple progress messages while processing
+- 🔗 Settings panel for YouTube/TikTok links
 
 ## 🧪 Requirements
 - Python 3.10+
@@ -41,7 +46,8 @@ Top = voice or interview (this gets transcribed)
 
 Bottom = gameplay or background loop
 
-Hit Create, and you’ll get output.mp4 in the same folder as the top clip.
+Hit Create and the video is written to your chosen output file (defaults to
+`output.mp4` next to the top clip).
 
 ## 📑 Function Overview
 
@@ -50,7 +56,7 @@ Below is a quick reference of the main Python functions used by ShortsSplit.
 ### Fully Working
 
 - `run_app()` – launches the PySide6 interface.
-- `generate_short(top, bottom, model_size="base", device="auto")` – handles transcription and video stacking, returning the path to `output.mp4`.
+- `generate_short(top, bottom, model_size="base", device="auto", style=None, output_path=None, progress=None)` – handles transcription and video stacking, returning the path to the created video.
 - `build_stack(top, bottom, subtitle, out_path)` – calls FFmpeg to stack the clips and burn the subtitles. It tries GPU encoding first and falls back to CPU when necessary.
 - `transcribe(path, model_size="base", device="auto")` – uses `faster-whisper` to create short subtitle cues from the audio track.
 - `save_ass(cues, out_path, style=None)` – writes subtitle cues to an ASS file with a default style.

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,3 +1,4 @@
 from .shorts import generate_short
+from .utils import load_config, save_config
 
-__all__ = ["generate_short"]
+__all__ = ["generate_short", "load_config", "save_config"]

--- a/core/shorts.py
+++ b/core/shorts.py
@@ -4,6 +4,8 @@ import logging
 import tempfile
 from pathlib import Path
 
+from typing import Callable, Dict
+
 from .ffmpeg_handler import build_stack
 from .subtitle_utils import save_ass
 from .whisper_wrapper import transcribe
@@ -15,6 +17,9 @@ def generate_short(
     model_size: str = "base",
     *,
     device: str = "auto",
+    style: Dict[str, str | int] | None = None,
+    output_path: Path | str | None = None,
+    progress: Callable[[str], None] | None = None,
 ) -> Path:
     """
     Create a short stacked video using the two provided clips.
@@ -37,19 +42,29 @@ def generate_short(
     """
     top_path = Path(top)
     bottom_path = Path(bottom)
-    output_path = top_path.parent / "output.mp4"
+    if output_path is None:
+        output_path = top_path.parent / "output.mp4"
+    else:
+        output_path = Path(output_path)
 
+    if progress:
+        progress("Transcribing...")
     logging.info("Transcribing top clip: %s", top_path)
     cues = transcribe(top_path, model_size=model_size, device=device)
 
     with tempfile.NamedTemporaryFile(suffix=".ass", delete=False) as tmp:
         subtitle_path = Path(tmp.name)
-        save_ass(cues, subtitle_path)
+        save_ass(cues, subtitle_path, style=style)
 
     try:
+        if progress:
+            progress("Encoding...")
         logging.info("Building stacked video -> %s", output_path)
         build_stack(top_path, bottom_path, subtitle_path, output_path)
     finally:
         subtitle_path.unlink(missing_ok=True)
+
+    if progress:
+        progress("Done")
 
     return output_path

--- a/core/utils.py
+++ b/core/utils.py
@@ -5,6 +5,9 @@ import subprocess
 from pathlib import Path
 
 
+CONFIG_PATH = Path.home() / ".shortssplit.json"
+
+
 def check_ffmpeg() -> None:
     """Ensure ffmpeg and ffprobe are available."""
     for tool in ("ffmpeg", "ffprobe"):
@@ -34,3 +37,22 @@ def probe_duration(path: Path) -> float:
         raise RuntimeError(f"ffprobe failed: {result.stderr}")
     data = json.loads(result.stdout)
     return float(data["format"]["duration"])
+
+
+def load_config() -> dict:
+    """Return configuration from ``CONFIG_PATH`` if present."""
+    if CONFIG_PATH.exists():
+        try:
+            with CONFIG_PATH.open("r", encoding="utf-8") as f:
+                return json.load(f)
+        except Exception as exc:  # pragma: no cover - best effort
+            logging.warning("Failed to read config: %s", exc)
+    return {}
+
+
+def save_config(cfg: dict) -> None:
+    """Write ``cfg`` to ``CONFIG_PATH``."""
+    try:
+        CONFIG_PATH.write_text(json.dumps(cfg, indent=2), encoding="utf-8")
+    except Exception as exc:  # pragma: no cover - best effort
+        logging.warning("Failed to write config: %s", exc)

--- a/ui/mainwindow.py
+++ b/ui/mainwindow.py
@@ -8,17 +8,24 @@ from PySide6.QtWidgets import (
     QFrame,
     QApplication,
     QMessageBox,
+    QLineEdit,
+    QComboBox,
+    QDialog,
+    QDialogButtonBox,
 )
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QFont
 
-from core import generate_short
+from core import generate_short, load_config, save_config
+from core.subtitle_utils import DEFAULT_STYLE
 
 class MainWindow(QWidget):
     def __init__(self):
         super().__init__()
+        self.config = load_config()
+
         self.setWindowTitle("ShortsSplit 🐢")
-        self.setMinimumSize(500, 400)
+        self.setMinimumSize(500, 450)
         self.setStyleSheet(self.stylesheet())
 
         layout = QVBoxLayout()
@@ -45,11 +52,27 @@ class MainWindow(QWidget):
         self.bottom_button.clicked.connect(lambda: self.load_file("bottom"))
         layout.addWidget(self.bottom_button)
 
+        self.output_button = QPushButton("📁 Set Output File")
+        self.output_button.clicked.connect(self.set_output)
+        layout.addWidget(self.output_button)
+
         self.create_button = QPushButton("⚙️ Create Shorts Video")
         self.create_button.clicked.connect(self.create_short)
         layout.addWidget(self.create_button)
 
+        self.settings_button = QPushButton("🔧 Settings")
+        self.settings_button.clicked.connect(self.open_settings)
+        layout.addWidget(self.settings_button)
+
+        self.status_label = QLabel("")
+        layout.addWidget(self.status_label)
+
         self.setLayout(layout)
+
+        # Load saved paths
+        for clip in ("top", "bottom"):
+            if clip_path := self.config.get(f"{clip}_clip"):
+                setattr(self, f"{clip}_clip", clip_path)
 
     def divider(self):
         line = QFrame()
@@ -62,9 +85,16 @@ class MainWindow(QWidget):
         file_dialog = QFileDialog()
         file_path, _ = file_dialog.getOpenFileName(self, f"Select {clip_type.capitalize()} Clip")
         if file_path:
-            print(f"Loaded {clip_type} clip: {file_path}")
-            # Store file path in self for later use
             setattr(self, f"{clip_type}_clip", file_path)
+            self.config[f"{clip_type}_clip"] = file_path
+            save_config(self.config)
+
+    def set_output(self):
+        file_dialog = QFileDialog()
+        path, _ = file_dialog.getSaveFileName(self, "Select Output File", self.config.get("output_path", "output.mp4"), "MP4 files (*.mp4)")
+        if path:
+            self.config["output_path"] = path
+            save_config(self.config)
 
     def create_short(self):
         try:
@@ -74,9 +104,28 @@ class MainWindow(QWidget):
             QMessageBox.warning(self, "Missing Clips", "Load both top and bottom clips first.")
             return
 
-        print("Generating short...")
-        output = generate_short(top, bottom)
+        def progress(msg: str) -> None:
+            self.status_label.setText(msg)
+            QApplication.processEvents()
+
+        output = generate_short(
+            top,
+            bottom,
+            device=self.config.get("device", "auto"),
+            style=self.config.get("subtitle_style"),
+            output_path=self.config.get("output_path"),
+            progress=progress,
+        )
         QMessageBox.information(self, "Done", f"Created {output}")
+        self.status_label.setText(f"Created {output}")
+        self.config["top_clip"] = top
+        self.config["bottom_clip"] = bottom
+        save_config(self.config)
+
+    def open_settings(self):
+        dialog = SettingsDialog(self.config)
+        if dialog.exec():
+            save_config(self.config)
 
     def stylesheet(self):
         return """
@@ -102,6 +151,72 @@ class MainWindow(QWidget):
             color: #f0f0f0;
         }
         """
+
+
+class SettingsDialog(QDialog):
+    def __init__(self, config: dict):
+        super().__init__()
+        self.setWindowTitle("Settings")
+        self.config = config
+        layout = QVBoxLayout()
+
+        layout.addWidget(QLabel("Whisper device:"))
+        self.device_combo = QComboBox()
+        self.device_combo.addItems(["auto", "cpu", "cuda"])
+        self.device_combo.setCurrentText(config.get("device", "auto"))
+        layout.addWidget(self.device_combo)
+
+        style = config.get("subtitle_style", DEFAULT_STYLE)
+        layout.addWidget(QLabel("Subtitle font:"))
+        self.font_edit = QLineEdit(style.get("FontName", "Arial"))
+        layout.addWidget(self.font_edit)
+
+        layout.addWidget(QLabel("Font size:"))
+        self.size_edit = QLineEdit(str(style.get("FontSize", 36)))
+        layout.addWidget(self.size_edit)
+
+        layout.addWidget(QLabel("Primary colour:"))
+        self.primary_edit = QLineEdit(style.get("PrimaryColour", "&H00FFFFFF"))
+        layout.addWidget(self.primary_edit)
+
+        layout.addWidget(QLabel("Outline colour:"))
+        self.outline_edit = QLineEdit(style.get("OutlineColour", "&H00000000"))
+        layout.addWidget(self.outline_edit)
+
+        layout.addWidget(QLabel("Outline width:"))
+        self.outline_width_edit = QLineEdit(str(style.get("Outline", 2)))
+        layout.addWidget(self.outline_width_edit)
+
+        layout.addWidget(QLabel("YouTube URL:"))
+        self.youtube_edit = QLineEdit(config.get("youtube", ""))
+        layout.addWidget(self.youtube_edit)
+
+        layout.addWidget(QLabel("TikTok URL:"))
+        self.tiktok_edit = QLineEdit(config.get("tiktok", ""))
+        layout.addWidget(self.tiktok_edit)
+
+        buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+        self.setLayout(layout)
+
+    def accept(self) -> None:
+        self.config["device"] = self.device_combo.currentText()
+        self.config["youtube"] = self.youtube_edit.text()
+        self.config["tiktok"] = self.tiktok_edit.text()
+        self.config["subtitle_style"] = {
+            "FontName": self.font_edit.text() or DEFAULT_STYLE["FontName"],
+            "FontSize": int(self.size_edit.text() or DEFAULT_STYLE["FontSize"]),
+            "PrimaryColour": self.primary_edit.text() or DEFAULT_STYLE["PrimaryColour"],
+            "OutlineColour": self.outline_edit.text() or DEFAULT_STYLE["OutlineColour"],
+            "BorderStyle": 1,
+            "Outline": int(self.outline_width_edit.text() or DEFAULT_STYLE["Outline"]),
+            "Shadow": 0,
+            "Alignment": 2,
+        }
+        super().accept()
 
 
 def run_app() -> None:


### PR DESCRIPTION
## Summary
- store settings in `~/.shortssplit.json`
- expose load/save helpers from core
- allow custom style, output path and progress callback in `generate_short`
- expand UI with output path selector, settings dialog and status label
- update README for the new features

## Testing
- `python -m py_compile core/*.py ui/*.py shortssplit.py`

------
https://chatgpt.com/codex/tasks/task_e_685113dd91e8832fb4e2f483295dd76b