### PR TITLE
Implement CLI and cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ Run it like a boss:
 python shortssplit.py
 ```
 
+Or run it from the terminal with your clips:
+
+```bash
+python shortssplit.py top.mp4 bottom.mp4 -o final.mp4
+```
+
 The transcriber tries to use your GPU first. If CUDA libraries are missing, it
 falls back to CPU automatically. You can force CPU mode by setting:
 

--- a/TODO.md
+++ b/TODO.md
@@ -10,9 +10,7 @@ This is the "make it actually usable and slightly less cursed" list for getting 
 - [ ] Subtitle burning (ASS) into top clip works cleanly with user styling
 - [ ] Bottom clip aligns/loops/trims to match top clip duration
 - [ ] Audio only comes from top clip and is volume-normalized
-- [ ] Output saves correctly and consistently (default + manual paths)
 - [ ] GPU fallback to CPU works without crashing
-- [ ] FFmpeg errors and subprocess issues are caught and logged
 
 ---
 
@@ -21,7 +19,6 @@ This is the "make it actually usable and slightly less cursed" list for getting 
 - [ ] Clear labeling for top (voice) and bottom (visual) clip inputs
 - [ ] Progress/status updates shown during processing
 - [ ] Light/dark mode toggle (even a dummy one is fine)
-- [ ] Remember last used files and settings
 - [ ] "Create" button triggers complete render chain, with feedback
 
 ---
@@ -45,9 +42,6 @@ This is the "make it actually usable and slightly less cursed" list for getting 
 
 ## 📦 Packaging and Delivery
 
-- [ ] `requirements.txt` is accurate and up-to-date
-- [ ] README includes simple usage guide (drag-drop > click > profit)
-- [ ] CLI option documented for terminal enjoyers
 - [ ] PyInstaller build script for lazy end users (optional but nice)
 - [ ] Version tag (0.9 or 1.0 depending on confidence)
 

--- a/core/shorts.py
+++ b/core/shorts.py
@@ -46,6 +46,7 @@ def generate_short(
         output_path = top_path.parent / "output.mp4"
     else:
         output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
 
     if progress:
         progress("Transcribing...")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-ffmpeg-python
 faster-whisper
 PySide6

--- a/shortssplit.py
+++ b/shortssplit.py
@@ -1,15 +1,51 @@
 """Entry point for ShortsSplit."""
+
+import argparse
 import logging
 
+from core import generate_short, load_config, save_config
 from core.utils import check_ffmpeg
 from ui.mainwindow import run_app
 
 
-if __name__ == "__main__":
+def main() -> int:
+    """Run ShortsSplit either via the GUI or the command line."""
+    parser = argparse.ArgumentParser(description="Create vertical shorts")
+    parser.add_argument("top", nargs="?", help="Top clip with audio")
+    parser.add_argument("bottom", nargs="?", help="Bottom clip video")
+    parser.add_argument("-o", "--output", help="Output file path")
+    parser.add_argument("-m", "--model", default="base", help="Whisper model size")
+    parser.add_argument("-d", "--device", default="auto", help="Whisper device")
+    args = parser.parse_args()
+
     logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(message)s")
+
     try:
         check_ffmpeg()
     except EnvironmentError as exc:
         logging.error(exc)
-    else:
-        run_app()
+        return 1
+
+    cfg = load_config()
+    top = args.top or cfg.get("top_clip")
+    bottom = args.bottom or cfg.get("bottom_clip")
+
+    if top and bottom:
+        out = generate_short(
+            top,
+            bottom,
+            model_size=args.model,
+            device=args.device,
+            output_path=args.output,
+            progress=logging.info,
+        )
+        save_config({"top_clip": top, "bottom_clip": bottom})
+        print(out)
+        return 0
+
+    run_app()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a simple CLI to `shortssplit.py`
- improve ffmpeg error handling
- ensure output directory exists
- document CLI usage
- prune completed tasks from TODO
- drop unused dependency

## Testing
- `python -m py_compile shortssplit.py core/*.py ui/mainwindow.py`

------
https://chatgpt.com/codex/tasks/task_e_685135f3c584832fb325b32db093a56a