### PR TITLE
Add unit tests and lazy import

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,5 +1,21 @@
-from .shorts import generate_short
+"""Public API for the :mod:`core` package.
+
+Importing :mod:`shorts` pulls in heavy dependencies (``faster-whisper`` in
+particular).  Tests in lightweight environments may not have these optional
+packages installed, so ``generate_short`` is loaded lazily to avoid import
+errors when the function is unused.  ``load_config`` and ``save_config`` are
+cheap to import and exposed directly.
+"""
+
 from .utils import load_config, save_config
 from .version import __version__
+
+
+def generate_short(*args, **kwargs):
+    """Import :func:`~core.shorts.generate_short` on demand and execute it."""
+
+    from .shorts import generate_short as _generate_short
+
+    return _generate_short(*args, **kwargs)
 
 __all__ = ["generate_short", "load_config", "save_config", "__version__"]

--- a/tests/test_ffmpeg_handler.py
+++ b/tests/test_ffmpeg_handler.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+import subprocess
+
+import pytest
+
+from core import ffmpeg_handler
+
+
+class DummyCompleted:
+    def __init__(self):
+        self.stderr = b""
+
+
+def test_build_stack_fallback(monkeypatch, tmp_path):
+    top = tmp_path / "top.mp4"
+    bottom = tmp_path / "bottom.mp4"
+    sub = tmp_path / "sub.ass"
+    out = tmp_path / "out.mp4"
+    for f in (top, bottom, sub):
+        f.write_text("dummy")
+
+    calls = []
+
+    def fake_run(cmd, check=True, stderr=None):
+        calls.append(cmd)
+        if "h264_nvenc" in cmd:
+            raise subprocess.CalledProcessError(returncode=1, cmd=cmd, stderr=b"fail")
+        return DummyCompleted()
+
+    monkeypatch.setattr(ffmpeg_handler, "probe_duration", lambda p: 1.0)
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    ffmpeg_handler.build_stack(top, bottom, sub, out)
+
+    assert any("h264_nvenc" in c for c in calls[0])
+    assert any("libx264" in c for c in calls[1])

--- a/tests/test_subtitle_utils.py
+++ b/tests/test_subtitle_utils.py
@@ -1,0 +1,19 @@
+import os
+from pathlib import Path
+
+import pytest
+
+from core.subtitle_utils import _format_time, save_ass
+
+
+def test_format_time_zero():
+    assert _format_time(0) == "0:00:00.00"
+
+
+def test_save_ass_creates_file(tmp_path):
+    cues = [(0.0, 1.0, "hello")]
+    out = tmp_path / "out.ass"
+    save_ass(cues, out)
+    assert out.exists()
+    content = out.read_text()
+    assert "Dialogue: 0" in content

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+import json
+import shutil
+import subprocess
+
+import pytest
+
+from core import utils
+
+
+def test_validate_media_ok(tmp_path):
+    f = tmp_path / "video.mp4"
+    f.write_text("dummy")
+    utils.validate_media(f)
+
+
+def test_validate_media_bad_ext(tmp_path):
+    f = tmp_path / "video.txt"
+    f.write_text("dummy")
+    with pytest.raises(ValueError):
+        utils.validate_media(f)
+
+
+def test_validate_media_missing(tmp_path):
+    f = tmp_path / "missing.mp4"
+    with pytest.raises(FileNotFoundError):
+        utils.validate_media(f)
+
+
+def test_load_save_config(monkeypatch, tmp_path):
+    cfg_path = tmp_path / "config.json"
+    monkeypatch.setattr(utils, "CONFIG_PATH", cfg_path)
+    data = {"a": 1}
+    utils.save_config(data)
+    loaded = utils.load_config()
+    assert loaded == data
+
+
+def test_check_ffmpeg_missing(monkeypatch):
+    monkeypatch.setattr(shutil, "which", lambda x: None)
+    with pytest.raises(EnvironmentError):
+        utils.check_ffmpeg()


### PR DESCRIPTION
## Summary
- lazily import `generate_short` to avoid optional dependency failures
- add basic unit tests for utils, subtitle handling and ffmpeg helper

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68513d7700ec832fb24ed51496e163ed