### PR TITLE
Persist output path

### DIFF
--- a/ui/mainwindow.py
+++ b/ui/mainwindow.py
@@ -158,6 +158,10 @@ class MainWindow(QWidget):
         self.bottom_label.setAlignment(Qt.AlignCenter)
         layout.addWidget(self.bottom_label)
 
+        self.output_label = QLabel("Output file: none")
+        self.output_label.setAlignment(Qt.AlignCenter)
+        layout.addWidget(self.output_label)
+
         self.status_label = QLabel("")
         self.status_label.setAlignment(Qt.AlignCenter)
         self.status_label.setStyleSheet(
@@ -170,6 +174,10 @@ class MainWindow(QWidget):
                 setattr(self, f"{clip}_clip", clip_path)
                 label = self.top_label if clip == "top" else self.bottom_label
                 label.setText(f"{clip.capitalize()} clip: {clip_path}")
+
+        if out_path := self.config.get("output_path"):
+            self.output_path = out_path
+            self.output_label.setText(f"Output file: {out_path}")
 
     def load_file(self, which: str) -> None:
         path, _ = QFileDialog.getOpenFileName(self, f"Select {which} clip")
@@ -187,6 +195,9 @@ class MainWindow(QWidget):
         )
         if path:
             self.output_path = path
+            self.output_label.setText(f"Output file: {path}")
+            self.config["output_path"] = path
+            save_config(self.config)
 
     def update_status(self, msg: str) -> None:
         self.status_label.setText(msg)


### PR DESCRIPTION
## Summary
- track output path in config
- load/save output file preference in UI
- show selected output file in the main window

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68513f9867a4832fafb621f8d2f994aa