### PR TITLE
Escape single quotes in subtitle paths

### DIFF
--- a/core/ffmpeg_handler.py
+++ b/core/ffmpeg_handler.py
@@ -20,6 +20,7 @@ def build_stack(
     # Prepare subtitle path: forward slashes + escape the "C:" drive-colon
     sub_path = subtitle.as_posix()
     sub_path = re.sub(r'^([A-Za-z]):', r'\1\\:', sub_path, count=1)
+    sub_path = sub_path.replace("'", "\\'")
 
     # ASS subtitles
     sub_filter = f"ass='{sub_path}'"

--- a/tests/test_ffmpeg_handler.py
+++ b/tests/test_ffmpeg_handler.py
@@ -1,0 +1,38 @@
+import types
+import subprocess
+from pathlib import Path
+import sys
+
+# Add project root to sys.path
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+# Provide dummy faster_whisper module with WhisperModel attribute
+stub = types.ModuleType('faster_whisper')
+stub.WhisperModel = object
+sys.modules.setdefault('faster_whisper', stub)
+
+import core.ffmpeg_handler as ffmpeg_handler
+
+def test_subtitle_path_escaping(monkeypatch):
+    captured = {}
+
+    def fake_run(cmd, check, stderr):
+        captured['cmd'] = cmd
+        class Result:
+            returncode = 0
+            stderr = b''
+        return Result()
+
+    monkeypatch.setattr(ffmpeg_handler, 'probe_duration', lambda _: 1)
+    monkeypatch.setattr(subprocess, 'run', fake_run)
+
+    top = Path('top.mp4')
+    bottom = Path('bottom.mp4')
+    subtitle = Path("te'st.ass")
+    out = Path('out.mp4')
+
+    ffmpeg_handler.build_stack(top, bottom, subtitle, out)
+
+    cmd_str = ' '.join(captured['cmd'])
+    assert "te\\'st.ass" in cmd_str


### PR DESCRIPTION
## Summary
- escape single quotes when building the subtitle filter
- test FFmpeg command generation with a subtitle file containing a quote

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68514369bf9c832f95ba5aa9ee9fc9dc