### PR TITLE
Add font and color options

### DIFF
--- a/core/subtitle_utils.py
+++ b/core/subtitle_utils.py
@@ -61,3 +61,13 @@ def _format_time(seconds: float) -> str:
     secs, cs = divmod(cs_total, 100)
     return f"{hrs}:{mins:02}:{secs:02}.{cs:02}"
 
+
+def hex_to_ass(color: str) -> str:
+    """Return ASS ``PrimaryColour`` from ``#RRGGBB`` ``color``."""
+    if color.startswith("#"):
+        color = color[1:]
+    if len(color) != 6:
+        raise ValueError("Color must be in #RRGGBB format")
+    r, g, b = color[0:2], color[2:4], color[4:6]
+    return f"&H00{b}{g}{r}"
+

--- a/tests/test_subtitle_utils.py
+++ b/tests/test_subtitle_utils.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from core.subtitle_utils import _format_time, save_ass
+from core.subtitle_utils import _format_time, save_ass, hex_to_ass
 
 
 def test_format_time_zero():
@@ -17,3 +17,7 @@ def test_save_ass_creates_file(tmp_path):
     assert out.exists()
     content = out.read_text()
     assert "Dialogue: 0" in content
+
+
+def test_hex_to_ass():
+    assert hex_to_ass("#112233") == "&H00332211"


### PR DESCRIPTION
## Summary
- allow changing subtitle font and color
- persist font and color to the user config
- thread worker passes subtitle style
- support converting hex colors to ASS format
- test color conversion helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851a0980dfc832fb3bda9fecc089ab6