### PR TITLE
Add Next.js marketing site

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -1,0 +1,17 @@
+# ShortSplit Website
+
+This is a simple promotional website for **ShortSplit**, built with Next.js and Tailwind CSS. It showcases the tool and links to the GitHub repository.
+
+## Development
+
+```bash
+npm install
+npm run dev
+```
+
+## Production
+
+```bash
+npm run build
+npm start
+```

--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/website/app/layout.tsx
+++ b/website/app/layout.tsx
@@ -1,0 +1,22 @@
+import './globals.css'
+import { Inter } from 'next/font/google'
+import type { ReactNode } from 'react'
+
+const inter = Inter({ subsets: ['latin'] })
+
+export const metadata = {
+  title: 'ShortSplit',
+  description: 'Effortless vertical video stacking'
+}
+
+export default function RootLayout({
+  children,
+}: {
+  children: ReactNode
+}) {
+  return (
+    <html lang="en" className={inter.className}>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -1,0 +1,50 @@
+import Link from 'next/link'
+import { motion } from 'framer-motion'
+import { Rocket, Layers3, Cpu, Terminal } from 'lucide-react'
+import Feature from '../components/Feature'
+
+const features = [
+  {
+    icon: <Layers3 size={32} />,
+    title: 'Stack Clips Instantly',
+    description: 'Combine talking head and gameplay footage into perfect 1080x1920 shorts.'
+  },
+  {
+    icon: <Cpu size={32} />,
+    title: 'GPU/CPU Support',
+    description: 'Uses your GPU when available and gracefully falls back to CPU.'
+  },
+  {
+    icon: <Terminal size={32} />,
+    title: 'Local & Offline',
+    description: 'Runs completely offline with whisper-based transcription.'
+  }
+]
+
+export default function Home() {
+  return (
+    <main className="flex flex-col items-center px-6 py-12 space-y-12">
+      <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }}>
+        <h1 className="text-5xl font-bold text-center">ShortSplit</h1>
+        <p className="mt-4 text-center text-gray-600 text-lg max-w-2xl">
+          Effortless vertical video stacking with automatic subtitles.
+        </p>
+      </motion.div>
+
+      <div className="grid gap-8 sm:grid-cols-3">
+        {features.map((f, i) => (
+          <Feature key={i} icon={f.icon} title={f.title} description={f.description} />
+        ))}
+      </div>
+
+      <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ delay: 0.3 }}>
+        <Link
+          href="https://github.com/Dyhrrr/shortsplit"
+          className="inline-flex items-center gap-2 rounded bg-black px-6 py-3 text-white hover:bg-gray-800"
+        >
+          <Rocket size={20} /> Get the Tool
+        </Link>
+      </motion.div>
+    </main>
+  )
+}

--- a/website/components/Feature.tsx
+++ b/website/components/Feature.tsx
@@ -1,0 +1,23 @@
+import { motion } from 'framer-motion'
+import { ReactNode } from 'react'
+
+interface FeatureProps {
+  icon: ReactNode
+  title: string
+  description: string
+}
+
+export default function Feature({ icon, title, description }: FeatureProps) {
+  return (
+    <motion.div
+      className="flex flex-col items-center text-center space-y-2"
+      initial={{ opacity: 0, y: 20 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true }}
+    >
+      <div className="text-primary-500">{icon}</div>
+      <h3 className="text-xl font-semibold">{title}</h3>
+      <p className="text-gray-600 max-w-xs">{description}</p>
+    </motion.div>
+  )
+}

--- a/website/next-env.d.ts
+++ b/website/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/website/next.config.js
+++ b/website/next.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    appDir: true
+  }
+}
+
+module.exports = nextConfig

--- a/website/package.json
+++ b/website/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "shortsplit-site",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "13.4.19",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "tailwindcss": "^3.4.0",
+    "autoprefixer": "^10.4.14",
+    "postcss": "^8.4.21",
+    "framer-motion": "^10.12.16",
+    "lucide-react": "^0.263.0",
+    "@radix-ui/react-slot": "^1.0.2"
+  }
+}

--- a/website/postcss.config.js
+++ b/website/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/website/tailwind.config.js
+++ b/website/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './app/**/*.{ts,tsx}',
+    './components/**/*.{ts,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node"],
+    "baseUrl": "."
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- set up a minimal Next.js site for promoting ShortSplit
- add Tailwind CSS and Framer Motion for styling and animations
- include a small feature list and link to the repo

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852a59dfaac832f9f4780f3b41ab9d1